### PR TITLE
Update lua library location

### DIFF
--- a/spaces/Makefile.template
+++ b/spaces/Makefile.template
@@ -6,7 +6,7 @@ LUAFILE  = init.lua
 SOFILE  := {SOFILE}
 
 CC=cc
-CFLAGS  += -Wall -Wextra -I ../../Pods/lua/src -I /usr/local/include/lua5.2 -fobjc-arc $(EXTRA_CFLAGS)
+CFLAGS  += -Wall -Wextra -I ../../Pods/lua/src -I /Applications/Hammerspoon.app/Contents/Resources/lua/ -fobjc-arc $(EXTRA_CFLAGS)
 LDFLAGS += -dynamiclib -undefined dynamic_lookup $(EXTRA_LDFLAGS)
 
 all: $(SOFILE)


### PR DESCRIPTION
Without this change, make succeeds with the warning:
internal.m:82:5: warning: implicit declaration of function 'luaL_newlib' is invalid in C99
      [-Wimplicit-function-declaration]

However, when calling 
spaces = require("hs._asm.undocumented.spaces")
in my init.lua, then reloading, it results in the following error:

---

error loading module 'hs._asm.undocumented.spaces.internal-spaces' from file '/Users/drogers/.hammerspoon/hs/_asm/undocumented/spaces/internal-spaces.so':
    dlopen(/Users/drogers/.hammerspoon/hs/_asm/undocumented/spaces/internal-spaces.so, 6): Symbol not found: _luaL_newlib
  Referenced from: /Users/drogers/.hammerspoon/hs/_asm/undocumented/spaces/internal-spaces.so
  Expected in: flat namespace
 in /Users/drogers/.hammerspoon/hs/_asm/undocumented/spaces/internal-spaces.so
stack traceback:
    [C]: in ?
    [C]: in function 'rawrequire'
    /Applications/Hammerspoon.app/Contents/Resources/setup.lua:177: in function 'require'
    ...rogers/.hammerspoon/hs/_asm/undocumented/spaces/init.lua:9: in main chunk
    [C]: in function 'rawrequire'
    /Applications/Hammerspoon.app/Contents/Resources/setup.lua:177: in function 'require'
    /Users/drogers/.hammerspoon/init.lua:27: in main chunk
    [C]: in function 'xpcall'
    /Applications/Hammerspoon.app/Contents/Resources/setup.lua:242: in main chunk

---

I had no problem after the change.

By the way - thanks for making this available, hopefully Apple will make something available publicly in the future.  Also - I noticed that the README.md shows the api without camelCase - ie spaces.currentspace(), but it is actually spaces.currentSpace().
